### PR TITLE
Enable builds with Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,71 @@
+name: Build
+
+on:
+  push:
+    branches: [master]
+    tags:
+      - '*'
+  pull_request:
+    branches: [master]
+
+jobs:
+  windows:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: |
+        cmake -B ${{github.workspace}}/build -A x64
+        cmake --build ${{github.workspace}}/build --config Release
+    - name: Upload windows build
+      uses: actions/upload-artifact@v2
+      with:
+        name: windows
+        path: ${{github.workspace}}/build/Analyzers/Release/*.dll
+  macos:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: |
+        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release
+        cmake --build ${{github.workspace}}/build
+    - name: Upload MacOS build
+      uses: actions/upload-artifact@v2
+      with:
+        name: macos
+        path: ${{github.workspace}}/build/Analyzers/*.so
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: |
+        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release
+        cmake --build ${{github.workspace}}/build
+    - name: Upload Linux build
+      uses: actions/upload-artifact@v2
+      with:
+        name: linux
+        path: ${{github.workspace}}/build/Analyzers/*.so
+  publish:
+    needs: [windows, macos, linux]
+    runs-on: ubuntu-latest
+    steps:
+    - name: download individual builds
+      uses: actions/download-artifact@v2
+      with:
+        path: ${{github.workspace}}/artifacts
+    - name: zip
+      run: |
+        cd ${{github.workspace}}/artifacts
+        zip -r ${{github.workspace}}/analyzer.zip .
+    - uses: actions/upload-artifact@v2
+      with:
+        name: all-platforms
+        path: ${{github.workspace}}/artifacts/**
+    - name: create release
+      uses: softprops/action-gh-release@v1
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+          files: ${{github.workspace}}/analyzer.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,8 @@ on:
       - '*'
   pull_request:
     branches: [master]
-
+  workflow_dispatch:
+  
 jobs:
   windows:
     runs-on: windows-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
     - name: zip
       run: |
         cd ${{github.workspace}}/artifacts
-        zip -r ${{github.workspace}}/analyzer.zip .
+        zip -r ${{github.workspace}}/SaleaeSDIOAnalyzer-${{github.ref_name}}.zip .
     - uses: actions/upload-artifact@v2
       with:
         name: all-platforms
@@ -68,4 +68,4 @@ jobs:
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')
       with:
-          files: ${{github.workspace}}/analyzer.zip
+          files: ${{github.workspace}}/SaleaeSDIOAnalyzer-${{github.ref_name}}.zip


### PR DESCRIPTION
This PR adds a Github action to automatically build and release binaries for the analyzer, as suggested in #10.

You may need to enable write permission for the actions to be able to upload the artifacts: https://stackoverflow.com/a/75250838/1024